### PR TITLE
Fix for logging, privilege reassignment, and a cleaner shutdown message

### DIFF
--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -57,14 +57,15 @@ module Dante
 
         # If a username, uid, groupname, or gid is passed,
         # drop privileges accordingly.
-        if options[:user]
-          uid = options[:user].is_a?(Integer) ? options[:user] : Etc.getpwnam(options[:user]).uid
-          Process::Sys.setuid(uid)
-        end
 
         if options[:group]
           gid = options[:group].is_a?(Integer) ? options[:group] : Etc.getgrnam(options[:group]).gid
-          Process::Sys.setegid(gid)
+          Process::GID.change_privilege(gid)
+        end
+
+        if options[:user]
+          uid = options[:user].is_a?(Integer) ? options[:user] : Etc.getpwnam(options[:user]).uid
+          Process::UID.change_privilege(uid)
         end
 
         @startup_command = block if block_given?

--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -128,8 +128,12 @@ module Dante
     end
 
     def interrupt
-      raise Interrupt
-      sleep(1)
+      begin
+        raise Interrupt
+        sleep(1)
+      rescue Interrupt
+        log "Interrupt received; stopping #{@name}"
+      end
     end
 
     # Returns true if process is not running

--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -220,10 +220,10 @@ module Dante
     def redirect_output!
       if log_path = options[:log_path]
         FileUtils.touch log_path
-        File.open(log_path, 'a') do |f|
-          $stdout.reopen(f)
-          $stderr.reopen(f)
-        end
+        STDOUT.reopen(log_path, 'a')
+        STDERR.reopen STDOUT
+        File.chmod(0644, log_path)
+        STDOUT.sync = true
       else # redirect to /dev/null
         STDIN.reopen "/dev/null"
         STDOUT.reopen "/dev/null", "a"

--- a/lib/dante/version.rb
+++ b/lib/dante/version.rb
@@ -1,3 +1,3 @@
 module Dante
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
I had to use these particular features of Dante, and I noticed that user and group reassignment weren't functioning correctly. While fixing them I also discovered that logfile redirection wasn't working right either (logs were being buffered and flushed on close, instead of being synced to disk in real time). I rewrote both pieces of functionality. 

Privilege dropping was rewritten following the guidelines laid out by [Joe Damato](http://timetobleed.com/5-things-you-dont-know-about-user-ids-that-will-destroy-you/), and work as expected (with the added bonus that user and group will accept UID or GID numbers in addition to user names now). The original behavior was verified using this script:

``` ruby
#!/usr/bin/env ruby

require 'rubygems'
require 'dante'

Dante.run('dante_test',
          :log_path => './test.log',
          :pid_path => './test.pid'
         ) do |opts|

  puts "uid #{Process.uid}, euid #{Process.euid}, gid #{Process.gid}"

end
```

With Dante 0.1.3, that results in this outcome:

<pre>
redrobot tmp # ./dante_test_privs.rb
Starting dante_test service...
uid 0, euid 0, gid 0

redrobot tmp # ./dante_test_privs.rb --user ryan
/usr/lib64/ruby/gems/1.9.1/gems/dante-0.1.3/lib/dante/runner.rb:56:in `euid=': can't convert String into Integer (TypeError)
  from /usr/lib64/ruby/gems/1.9.1/gems/dante-0.1.3/lib/dante/runner.rb:56:in `execute'
  from /usr/lib64/ruby/gems/1.9.1/gems/dante-0.1.3/lib/dante.rb:24:in `run'
  from ./dante_test_privs.rb:6:in `<main>'
</pre>


After this patch, behavior is as expected; UID/GID switching requires that the daemon be started as root, the same as any other UNIX/Linux daemon and GID changing has been moved ahead of UID changing, because if the UID is dropped than the ability the change GID is effectively limited. The results of that script are now:

<pre>
redrobot tmp # ./dante_test_privs.rb 
Starting dante_test service...
uid 0, euid 0, gid 0

redrobot tmp # ./dante_test_privs.rb --user ryan
Starting dante_test service...
uid 500, euid 500, gid 0

redrobot tmp # ./dante_test_privs.rb --group ryan
Starting dante_test service...
uid 0, euid 0, gid 500
</pre>


Log file redirection has been slightly reworked to be a little bit more concise and to flush to disk in realtime and the `interrupt` method now catches the interrupt flag and processes it cleanly, without the accompanying stack trace.
