### PR TITLE
Fixes and cleanup for `redirect_output`, `kill_pid`, `interrupt`, and `log` as well as tests.

### DIFF
--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -103,8 +103,9 @@ module Dante
         interrupt
         exit
       }
+
       trap("TERM"){
-        interrupt
+        log "Trying to stop #{@name}..."
         exit
       }
 
@@ -128,10 +129,10 @@ module Dante
     end
 
     def interrupt
-      begin
+      if options[:debug]
         raise Interrupt
-        sleep(1)
-      rescue Interrupt
+        sleep 1
+      else
         log "Interrupt received; stopping #{@name}"
       end
     end
@@ -211,7 +212,7 @@ module Dante
         begin
           pid = IO.read(f).chomp.to_i
           FileUtils.rm f
-          Process.kill('INT', pid)
+          Process.kill('TERM', pid)
           log "Stopped PID: #{pid} at #{f}"
         rescue => e
           log "Failed to stop! #{k}: #{e}"
@@ -223,17 +224,25 @@ module Dante
     # If log_path is nil, redirect to /dev/null to quiet output
     def redirect_output!
       if log_path = options[:log_path]
+        # if the log directory doesn't exist, create it
+        FileUtils.mkdir_p File.dirname(options[:log_path]), :mode => 0755
+        # touch the log file to create it
         FileUtils.touch log_path
-        STDOUT.reopen(log_path, 'a')
-        STDERR.reopen STDOUT
+        # Set permissions on the log file
         File.chmod(0644, log_path)
-        STDOUT.sync = true
+        # Reopen $stdout (NOT +STDOUT+) to start writing to the log file
+        $stdout.reopen(log_path, 'a')
+        # Redirect $stderr to $stdout
+        $stderr.reopen $stdout
+        $stdout.sync = true
       else # redirect to /dev/null
-        STDIN.reopen "/dev/null"
-        STDOUT.reopen "/dev/null", "a"
-        STDERR.reopen STDOUT
+        # We're not bothering to sync if we're dumping to /dev/null
+        # because /dev/null doesn't care about buffered output
+        $stdin.reopen '/dev/null'
+        $stdout.reopen '/dev/null', 'a'
+        $stderr.reopen $stdout
       end
-      log_path = options[:log_path] ? options[:log_path] : "/dev/null"
+      log_path = options[:log_path] ? options[:log_path] : '/dev/null'
     end
 
     # Runs until the block condition is met or the timeout_seconds is exceeded
@@ -248,7 +257,7 @@ module Dante
     end
 
     def log(message)
-      puts message if options[:debug]
+      puts message
     end
 
   end

--- a/lib/dante/version.rb
+++ b/lib/dante/version.rb
@@ -1,3 +1,3 @@
 module Dante
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
My previous patch to make `interrupt` cleaner was poorly thought out.
`interrupt` will now only raise if :debug is set, otherwise it passes a
logged message.

`kill_pid` now uses SIGTERM instead of SIGINT since stopping a daemon
cleanly isn't actually the same as interrupting a running process from
the terminal; SIGTERM is more appropriate than SIGINT in that context.

After changing the handling of SIGTERM in runner.rb, the test
needed to be updated to accommodate the fact that SIGTERM is no
longer processed as SIGINT. I've also rolled in a test to validate that
SIGINT and SIGTERM are being handled differently. All tests now pass 
(though 'Daemon has started successfully' will be written to the console
vis STDOUT now; not sure how to safely suppress it in the context of the
tests).

`log` has also been changed so that all messages are logged, regardless of
debug mode. This is more in-line with how C daemons work. I think that it
could be refactored to use Logger but for now it will provide a relatively
reliable audit trail for applications flapping.

`redirect_output` has been updated to use $stdout, $stderr, and $stdin instead of STDOUT, STDERR, and STDIN. The uppercase-constants are generally used to reset the lowercase-aliases after they've been changed so changing them is considered bad form. Oops.
