### PR TITLE
Validation Hook for Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ runner.with_options do |opts|
     options[:test] = test
   end
 end
+# Create validation hook for options
+runner.verify_options_hook = lambda { |opts|
+  raise Exception.new("Must supply test parameter") if opts[:test].nil?
+}
 # Parse command-line options and execute the process
 runner.execute do |opts|
   # opts: host, pid_path, port, daemonize, user, group

--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -50,7 +50,7 @@ module Dante
       parse_options
       self.options.merge!(opts)
 
-      @verify_options_hook.call() if @verify_options_hook
+      @verify_options_hook.call(self.options) if @verify_options_hook
 
       if options.include?(:kill)
         self.stop

--- a/lib/dante/runner.rb
+++ b/lib/dante/runner.rb
@@ -18,7 +18,7 @@ module Dante
   class Runner
     MAX_START_TRIES = 5
 
-    attr_accessor :options, :name, :description
+    attr_accessor :options, :name, :description, :verify_options_hook
 
     class << self
       def run(*args, &block)
@@ -49,6 +49,8 @@ module Dante
     def execute(opts={}, &block)
       parse_options
       self.options.merge!(opts)
+
+      @verify_options_hook.call() if @verify_options_hook
 
       if options.include?(:kill)
         self.stop

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -4,12 +4,12 @@ describe "dante runner" do
 
   describe "verify options fails" do
     it "should bubble up exception" do
-      runner = Dante::Runner.new('test-process') {
+      runner = Dante::Runner.new('test-process', {key1:"val2"}) {
         raise Exception.new("should not get here!!!")
       }
 
-      runner.verify_options_hook = lambda {
-        raise Exception.new("Look for this exception")
+      runner.verify_options_hook = lambda { |opts|
+        raise Exception.new("Look for this exception") if(opts[:key1] != "val1")
       }
 
       err = assert_raises(Exception) {

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -1,6 +1,25 @@
 require File.expand_path('../test_helper', __FILE__)
 
 describe "dante runner" do
+
+  describe "verify options fails" do
+    it "should bubble up exception" do
+      runner = Dante::Runner.new('test-process') {
+        raise Exception.new("should not get here!!!")
+      }
+
+      runner.verify_options_hook = lambda {
+        raise Exception.new("Look for this exception")
+      }
+
+      err = assert_raises(Exception) {
+        runner.execute
+      }
+
+      assert_equal(err.message, "Look for this exception")
+    end
+  end
+
   describe "with no daemonize" do
     before do
       @process = TestingProcess.new('a')


### PR DESCRIPTION
Allow users to add a lambda as a validation hook before the daemon is forked.
