### PR TITLE
Add a Force option for force killing

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,4 +64,14 @@ class TestingProcess
   ensure
     puts "Closing!!"
   end
+
+  def run_d!(data=nil)
+    begin
+      p ['The rescuer']
+      sleep 100
+    rescue SystemExit, SignalException => e
+      p ['Saved']
+    end
+  end
+
 end # TestingProcess


### PR DESCRIPTION
Allow user to specify a hard stop (`SIGKILL`) when fails to stop after `MAX_START_TRIES` attempts.  This will ensure the daemon is fully shut-down.  Only applies if user adds a `-f` command-line flag.
